### PR TITLE
PDF book build fails due to bad Filters.hs

### DIFF
--- a/filters/Figures.hs
+++ b/filters/Figures.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-@ LIQUID "--no-termination" @-}
 
 module Figures where
@@ -73,7 +74,7 @@ txFigures ch tgt prefix templateF
 resetChapter LATEX _        _ = return ()
 resetChapter HTML  Nothing  _ = return ()
 resetChapter HTML  (Just n) r = replicateM_ (n-1) (newChapter r)
- 
+
 tx tgt prefix t r b0
   = do b1 <- txBlock tgt prefix t r b0
        b2 <- txLink               r b1
@@ -94,7 +95,7 @@ txBlock _   _      _ r z@(Header 1 _ _)
 
 txBlock tgt prefix t r (Div (id, [cls], kvs) _)
   | isFigure cls
-  = makeFigure tgt prefix t r id cls kvs 
+  = makeFigure tgt prefix t r id cls kvs
 
 txBlock _ _ _ _ z
   = return z -- $ trace ("IAMTHIS:" ++ show z) z
@@ -149,4 +150,3 @@ getCount r id
 newChapter r
   = do info <- readIORef r
        writeIORef r (info {count = 1, chapter = 1 + chapter info})
-


### PR DESCRIPTION
While attempting to build the .pdf book, I received the following error:

```
pandoc: Error running filter filters/Figures.hs
fd:4: hPutBuf: resource vanished (Broken pipe)
Makefile:60: recipe for target 'pdf' failed
make: *** [pdf] Error 83
```

Lack of flexible contexts was preventing `txLink` from typechecking. Due to this, I was unable to compile `Figures.hs`, and unable to compile the .pdf file.

I've added `FlexibleContexts` to `Figures.hs`, `txLink` now typechecks and the build proceeds past this step.