### PR TITLE
Fixed lhsObjects in Makefile to be sorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ PANDOCT=pandoc --from=markdown --to=html --standalone
 
 ####################################################################
 
-lhsObjects  := $(wildcard src/*.lhs)
+lhsObjects  := $(sort $(wildcard src/*.lhs))
 texObjects  := $(patsubst %.lhs,%.tex,$(wildcard src/*.lhs))
 htmlObjects := $(patsubst %.lhs,%.html,$(wildcard src/*.lhs))
 


### PR DESCRIPTION
Changed the value of the `lhsObjects` variable in the `Makefile` to be sorted. Previously, the list was not sorted, and this was resulting in the book being compiled with the chapters in random order.