### PR TITLE
Update 02-logic.lhs

### DIFF
--- a/src/02-logic.lhs
+++ b/src/02-logic.lhs
@@ -376,7 +376,7 @@ Can you fix it to get a valid formula?
 
 \begin{code}
 {-@ exDeMorgan2 :: Bool -> Bool -> TRUE @-}
-exDeMorgan2 a b = not (a && b) <=> (not a || not b)
+exDeMorgan2 a b = not (a && b) <=> (not a && not b)
 \end{code}
 
 Examples: Arithmetic

--- a/src/02-logic.lhs
+++ b/src/02-logic.lhs
@@ -313,7 +313,7 @@ ex1 b = b || not b
 \end{code}
 
 \noindent Of course, a variable cannot be both `True`
-and `False`, and so the below predicate is invalid:
+and `False`, and so the below predicate is valid:
 
 \begin{code}
 {-@ ex2 :: Bool -> FALSE @-}

--- a/src/02-logic.lhs
+++ b/src/02-logic.lhs
@@ -376,7 +376,7 @@ Can you fix it to get a valid formula?
 
 \begin{code}
 {-@ exDeMorgan2 :: Bool -> Bool -> TRUE @-}
-exDeMorgan2 a b = not (a && b) <=> (not a && not b)
+exDeMorgan2 a b = not (a && b) <=> (not a || not b)
 \end{code}
 
 Examples: Arithmetic


### PR DESCRIPTION
The predicate b && not b always evaluate to FALSE and we are checking it against the refinement type FALSE which should be valid