### PR TITLE
Returning the wrong Q for the result of take

### DIFF
--- a/src/09-case-study-lazy-queues.lhs
+++ b/src/09-case-study-lazy-queues.lhs
@@ -360,7 +360,7 @@ done, `okTake` should be accepted, but `badTake` should be rejected.
 \begin{code}
 take           :: Int -> Queue a -> (Queue a, Queue a)
 take 0 q       = (emp          , q)
-take n q       = (insert x out , q')
+take n q       = (insert x out , q'')
   where
     (x  , q')  = remove q
     (out, q'') = take (n-1) q'


### PR DESCRIPTION
I'm pretty sure this should return `q''`, not `q'`