### PR TITLE
Replace `l` witn `ln`

### DIFF
--- a/src/11-case-study-pointers.lhs
+++ b/src/11-case-study-pointers.lhs
@@ -816,13 +816,13 @@ prefix and suffix at that point.
 
 \begin{code}
 {-@ spanByte :: Word8 -> b:ByteString -> ByteString2 b @-}
-spanByte c ps@(BS x s l)
+spanByte c ps@(BS x s ln)
   = unsafePerformIO
       $ withForeignPtr x $ \p ->
          go (p `plusPtr` s) 0
   where
     go p i
-      | i >= l    = return (ps, empty)
+      | i >= ln   = return (ps, empty)
       | otherwise = do c' <- peekByteOff p i
                        if c /= c'
                          then return $ splitAt i


### PR DESCRIPTION
It is too easy to confuse the lower case letter with the numeral one.

This is a general comment on the tutorial, I have not changed all of them.