### PR TITLE
Fix build error

### DIFF
--- a/src/02-logic.lhs
+++ b/src/02-logic.lhs
@@ -104,15 +104,15 @@ or the Boolean combination of the above predicates with the operators `&&` (and)
 if ^[Read `p <=> q` as "if `p` then `q` **and** if `q` then `p`"]), and `not`.
 
 ~~~~~{.spec}
-    p := true
-       | false
-       | e r e           -- atomic binary relation
-       | v e1 e2 ... en  -- predicate application
-       | p  && p         -- and
-       | p  || p         -- or
-       | p ==> p         -- implies
-       | p <=> p         -- if and only if
-       | not p           -- negation
+    p := (e r e)                -- binary relation
+       | (v e1 e2 ... en)       -- predicate (or alias) application
+       | (p && p)               -- and
+       | (p || p)               -- or
+       | (p => p) | (p ==> p)   -- implies
+       | (p <=> p)              -- iff
+       | (not p)                -- negation
+       | true | True
+       | false | False
 ~~~~~
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
 resolver: nightly-2017-11-22
-compiler-check: newer-minor
 flags: {}
 packages:
 - '.'


### PR DESCRIPTION
Error detail.

```
$ stack install

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for liquidhaskell-0.8.2.0:
    ghc-8.2.2 from stack configuration does not match ==8.2.1 (latest matching version is 8.2.1)
    ghc-boot-8.2.2 from stack configuration does not match ==8.2.1 (latest matching version is 8.2.1)
needed since liquidhaskell is a build target.

Some potential ways to resolve this:

  * Recommended action: try adding the following to your extra-deps in /home/bm12/repo/guchi/liquidhaskell-tutorial/stack.yaml:

- ghc-8.2.1
- ghc-boot-8.2.1

  * Set 'allow-newer: true' to ignore all version constraints and build anyway.

  * You may also want to try using the 'stack solver' command.

Plan construction failed.
```