### PR TITLE
Fix broken exercise in CH08

### DIFF
--- a/src/08-measure-sets.lhs
+++ b/src/08-measure-sets.lhs
@@ -453,7 +453,6 @@ unexpected signature for `mergeSort` below.
 \begin{code}
 {-@ mergeSort :: (Ord a) => xs:[a] -> ListEmp a @-}
 mergeSort []  = []
-mergeSort [x] = [x]
 mergeSort xs  = merge (mergeSort ys) (mergeSort zs)
   where
    (ys, zs)   = halve mid xs


### PR DESCRIPTION
It appears that this exercise wanted mergeSort to have a nontermination bug, allowing us to prove the incorrect proposition. This was fixed at some point, probably not realizing that it should be broken.