### PR TITLE
Fix bool value on chapter 6

### DIFF
--- a/src/Tutorial_06_Measure_Bool.lhs
+++ b/src/Tutorial_06_Measure_Bool.lhs
@@ -235,7 +235,7 @@ only invoke the respective functions with non-empty lists.
 Write down a specification for `null` such that `safeHead`
 is verified. Do *not* force `null` to only take non-empty inputs,
 that defeats the purpose. Instead, its type should say that it
-works on *all* lists and returns `True` *if and only if* the input
+works on *all* lists and returns `False` *if and only if* the input
 is non-empty.
 </div>
 


### PR DESCRIPTION
In the following section:

```haskell
<div class="hwex" id="Safe Head">
Write down a specification for `null` such that `safeHead`
is verified. Do *not* force `null` to only take non-empty inputs,
that defeats the purpose. Instead, its type should say that it
works on *all* lists and returns `True` *if and only if* the input
is non-empty.
</div>

\hint You may want to refresh your memory about implies `==>`
and `<=>` from the [chapter on logic](#semantics).

\begin{code}
safeHead      :: [a] -> Maybe a
safeHead xs
  | null xs   = Nothing
  | otherwise = Just $ head xs

{-@ null      :: [a] -> Bool @-}
null []       =  True
null (_:_)    =  False
\end{code}
```
I think that "all list and return True" should be "all list and returns False" given the current definition of null