### PR TITLE
Stop deferring type errors

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,7 @@ dependencies:
 - liquidhaskell
 
 library:
-  ghc-options: -fdefer-type-errors -fplugin=LiquidHaskell
+  ghc-options: -fplugin=LiquidHaskell
 
   source-dirs:
     - src


### PR DESCRIPTION
Previously the argument `-fdefer-type-errors` was passed to GHC. This could result in confusing errors when, for example, typos are included in source code, as GHC wouldn't catch the error, so LH would fail to compile with confusing error messages.

Merging this will fix #119.