### PR TITLE
fix broken links in bibliography

### DIFF
--- a/templates/bib.lhs
+++ b/templates/bib.lhs
@@ -1,36 +1,36 @@
 
 [mylink]:          http://www.google.com
-[dml]:             http://www.cs.bu.edu/~hwxi/DML/DML.html
-[vecspec]:         https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/Vector.spec
+[dml]:             https://en.wikipedia.org/wiki/Dependent_ML
+[vecspec]:         https://github.com/ucsd-progsys/liquidhaskell/blob/91e1074575ca102df810ea399c5a13063e8c8011/include/Data/Vector.spec
 [vec]:             http://hackage.haskell.org/package/vector
 [agdavec]:         http://code.haskell.org/Agda/examples/Vec.agda
 [ref101]:          /blog/2013/01/01/refinement-types-101.lhs/ 
 [ref102]:          /blog/2013/01/27/refinements-101-reax.lhs/ 
-[data-list]:       http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html
-[foldl]:           http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html
+[data-list]:       https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-List.html
+[foldl]:           https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-List.html#v:foldl
 [listtail]:        /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
-[dmlarray]:        http://www.cs.bu.edu/~hwxi/academic/papers/pldi98.pdf
+[dmlarray]:        https://www.cs.cmu.edu/~fp/papers/pldi98dml.pdf
 [liquid-tutorial]: http://github.com/ucsd-progsys/liquidhaskell-tutorial.git 
 [liquid-emacs]:    https://github.com/ucsd-progsys/liquid-types.el
 [liquid-vim]:      https://github.com/ucsd-progsys/liquid-types.vim
 [liquid-spacemacs]: https://github.com/ucsd-progsys/liquid-types-spacemacs
 [z3]:              https://github.com/Z3Prover/z3
-[cvc4]:            http://cvc4.cs.nyu.edu/ 
+[cvc4]:            https://cvc4.github.io/
 [mathsat]:         http://mathsat.fbk.eu/download.html
 [hoogle-assert]:   https://www.haskell.org/hoogle/?hoogle=assert
 [apple-riser]:     http://blog.jbapple.com/2008/01/extra-type-safety-using-polymorphic.html
 [safeList]:        /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
 [kmeansI]:         /blog/2013/02/16/kmeans-clustering-I.lhs/
 [kmeansII]:        /blog/2013/02/17/kmeans-clustering-II.lhs/
-[URL-take]:        https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/List.lhs#L334
+[URL-take]:        https://github.com/ucsd-progsys/liquidhaskell/blob/91e1074575ca102df810ea399c5a13063e8c8011/include/GHC/List.spec#L33
 [URL-groupBy]:     http://hackage.haskell.org/packages/archive/base/latest/doc/html/Data-List.html#v:groupBy
-[URL-transpose]:   http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html#transpose
+[URL-transpose]:   http://hackage.haskell.org/packages/archive/base/latest/doc/html/Data-List.html#v:transpose
 [maru]:            http://www.youtube.com/watch?v=8uDuls5TyNE
 [URL-kmeans]:      http://hackage.haskell.org/package/kmeans
 [hinze-icfp09]: http://www.cs.ox.ac.uk/ralf.hinze/publications/ICFP09.pdf
-[smt-set]:       http://www.kroening.com/smt-lib-lsm.pdf)
+[smt-set]:       http://www.kroening.com/smt-lib-lsm.pdf
 
-[setspec]:  https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/Set.spec
+[setspec]:        https://github.com/ucsd-progsys/liquidhaskell/blob/91e1074575ca102df810ea399c5a13063e8c8011/include/Data/Set.spec
 [mccarthy]: http://www-formal.stanford.edu/jmc/towards.ps
 [xmonad-stackset]: http://hackage.haskell.org/package/xmonad-0.11/docs/XMonad-StackSet.html
 
@@ -47,16 +47,16 @@
 [vazou13]:        http://goto.ucsd.edu/~rjhala/liquid/abstract_refinement_types.pdf
 [liquidpldi08]:   http://goto.ucsd.edu/~rjhala/liquid/liquid_types.pdf
 
-[bird-pearls]: http://www.amazon.com/Pearls-Functional-Algorithm-Design-Richard/dp/0521513383
+[bird-pearls]: https://www.cambridge.org/core/books/pearls-of-functional-algorithm-design/B0CF0AC5A205AF9491298684113B088F
 [mitchell-riser]:  http://neilmitchell.blogspot.com/2008/03/sorting-at-speed.html
 [blog-set]:        /blog/2013/03/26/talking-about-sets.lhs/
 [z3cal]:           http://research.microsoft.com/en-us/um/people/leonardo/fmcad09.pdf
 [sbv]:             https://github.com/LeventErkok/sbv
 [leon]:            http://lara.epfl.ch/w/leon
-[ptrspec]:  https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/Ptr.spec
+[ptrspec]:        https://github.com/ucsd-progsys/liquidhaskell/blob/91e1074575ca102df810ea399c5a13063e8c8011/include/GHC/Ptr.spec
 
 [okasaki95]: http://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp95queue.pdf
 
 [queue-wiki]: http://en.wikipedia.org/wiki/Queue_%28abstract_data_type%29
 [avl-wiki]: http://en.wikipedia.org/wiki/AVL_tree
-[nelson-thesis]: http://research.microsoft.com/en-us/um/people/qadeer/cse599f/papers/nelsonthesis.pdf
+[nelson-thesis]: https://people.eecs.berkeley.edu/~necula/Papers/nelson-thesis.pdf


### PR DESCRIPTION
Hi folks,

Today I started working through the tutorial and have been enjoying myself.  I noticed that the link to Greg Nelson's thesis is dead so I thought I would check if there were any others that failed to return an HTTP 200:

```
➜  liquidhaskell-tutorial git:(main) ✗ for URL in $(sed -e 's/^[^:]*:[ ]*//g' -e '/^$/d' -e '/^\/blog/d' templates/bib.lhs); do echo $URL $(curl -Lso /dev/null -w "%{http_code}" $URL); done | grep -v ' 200'
http://www.cs.bu.edu/~hwxi/DML/DML.html 404
https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/Vector.spec 404
http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html 404
http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html 404
http://www.cs.bu.edu/~hwxi/academic/papers/pldi98.pdf 404
http://cvc4.cs.nyu.edu/ 301
https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/List.lhs#L334 404
http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html#transpose 404
http://www.kroening.com/smt-lib-lsm.pdf) 403
https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/Set.spec 404
http://www.amazon.com/Pearls-Functional-Algorithm-Design-Richard/dp/0521513383 503
https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/Ptr.spec 404
➜  liquidhaskell-tutorial git:(main) ✗
```

There were a bunch (including but not limited to the one mentioned in #122.)  This patch fixes the above dead links as best I could.  (Nelson's thesis was _not_ among the above since it redirects to the root MSR homepage; I didn't explicitly vet any of the other ones that nominally return 200).

```
➜  liquidhaskell-tutorial git:(nathan/link_fixes) ✗ for URL in $(sed -e 's/^[^:]*:[ ]*//g' -e '/^$/d' -e '/^\/blog/d' templates/bib.lhs); do echo $URL $(curl -Lso /dev/null -w "%{http_code}" $URL); done | grep -v ' 200'
➜  liquidhaskell-tutorial git:(nathan/link_fixes) ✗
```

Well-typed greetings from Austin!

Nathan